### PR TITLE
Check for workspace existing and prioritize path setting

### DIFF
--- a/ext-src/uNotes.js
+++ b/ext-src/uNotes.js
@@ -60,12 +60,13 @@ class UNotes {
         this.currentNote = null;
         this.selectAfterRefresh = null;
 
-        if (!vscode.workspace.workspaceFolders) {
+        this.rootPath = vscode.workspace.getConfiguration('unotes').get('rootPath', '');
+        if (!this.rootPath && !vscode.workspace.workspaceFolders) {
             vscode.window.showWarningMessage("Please open a folder BEFORE using unotes.");
             return;
         }
 
-        if (vscode.workspace.workspaceFolders.length > 1) {
+        if (!this.rootPath && vscode.workspace.workspaceFolders.length > 1) {
             vscode.window.showWarningMessage("Warning: unotes currently does not support multiple workspaces.");
         }
 
@@ -141,7 +142,7 @@ class UNotes {
             vscode.commands.registerCommand('unotes.convertImages', this.onConvertImages.bind(this))
         );
 
-        if (Config.rootPath === vscode.workspace.workspaceFolders[0].uri.fsPath) {
+        if (vscode.workspace.workspaceFolders && Config.rootPath === vscode.workspace.workspaceFolders[0].uri.fsPath) {
             // Can't watch folders outside of workspace
             this.setupFSWatcher();
         }

--- a/ext-src/uNotesCommon.js
+++ b/ext-src/uNotesCommon.js
@@ -23,11 +23,11 @@ class UnotesConfig {
         this.settings = vscode.workspace.getConfiguration(extId);
         
         // root path setup
-        if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length == 0) {
-            return;
-        }        
         this.rootPath = this.settings.get('rootPath', '');
         if (!this.rootPath) {
+            if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length == 0) {
+                return;
+            }
             this.rootPath = vscode.workspace.workspaceFolders[0].uri.fsPath;
         }
         this.folderPath = path.join(this.rootPath, './.unotes');


### PR DESCRIPTION
This change should make the extension work without an open folder or with multiple folders, by first checking for the "rootPath" configuration. If the configuration is missing, behavior remains unchanged.

Testing done:
* Config unset:
  * Open extension with no folder open (extension won't open)
  * Open extension with one folder open (extension opens, .unotes created in first folder)
  * Open extension with multiple folders (extension opens with warning, .unotes created in first folder)
  * Repeat the above with .unotes folder already created, create, delete, move notes and folders
* Config set:
  * Open extension with no folder open (extension opens, .unotes created in config rootPath)
  * Open extension with one folder open (extension opens, .unotes created in config rootPath)
  * Open extension with multiple folders (extension opens, .unotes created in config rootPath)
  * Repeat the above with .unotes folder already created, create, delete, move notes and folders

Affected issues:
#8 