### PR TITLE
FIX: Support absolute path for Media Folder (#119)

### DIFF
--- a/editor/src/TuiEditor.js
+++ b/editor/src/TuiEditor.js
@@ -128,7 +128,11 @@ class TuiEditor extends Component {
                         return result;
                     }
                     if (entering) {
-                        result.attributes.src = img_root + node.destination;
+                        if (node.destination.startsWith('/')) {
+                            result.attributes.src = node.destination;
+                        } else {
+                            result.attributes.src = img_root + node.destination;
+                        }
                     }
                     return result;
                 }
@@ -157,7 +161,11 @@ class TuiEditor extends Component {
     }
 
     onHtmlBefore(e) {
-        return replaceAll(e, img_root, '');
+        let str = replaceAll(e, img_root, '');
+        if (str) {
+         str = replaceAll(str, 'file://', '');
+        }
+        return str;
     }
 
     onAfterMarkdown(e) {

--- a/ext-src/uNotesCommon.js
+++ b/ext-src/uNotesCommon.js
@@ -161,7 +161,10 @@ exports.Utils = {
      */
     async getNextImageIndex(folderPath) {
         let index = 0;
-        const mediaPath = path.join(folderPath, Config.mediaFolder);
+        let mediaPath = path.join(folderPath, Config.mediaFolder);
+        if (path.isAbsolute(Config.mediaFolder)) {
+            mediaPath = Config.mediaFolder;
+        }
         if(!await this.fileExists(mediaPath)){
             return 0;
         }
@@ -191,7 +194,10 @@ exports.Utils = {
      */
     async saveMediaImage(folderPath, imgBuffer, index, imgType) {
         let newIndex = index;
-        const mediaPath = path.join(folderPath, Config.mediaFolder);
+        let mediaPath = path.join(folderPath, Config.mediaFolder);
+        if (path.isAbsolute(Config.mediaFolder)) {
+            mediaPath = Config.mediaFolder;
+        }
 
         // create the folder if needed
         if(!await this.fileExists(mediaPath)){

--- a/ext-src/uNotesPanel.js
+++ b/ext-src/uNotesPanel.js
@@ -57,15 +57,18 @@ class UNotesPanel {
             this.currentPath = '';
             this.currentNote = null;
             this.imageToConvert = null;
-
+            let localResourceRoots = [
+                vscode.Uri.file(path.join(Config.rootPath)),
+                vscode.Uri.file(path.join(this.extensionPath, 'build'))
+            ]
+            if (Config.mediaFolder.startsWith('/')) {
+                localResourceRoots.push(vscode.Uri.file(Config.mediaFolder))
+            }
             this.panel = vscode.window.createWebviewPanel('unotes', "UNotes", { viewColumn: vscode.ViewColumn.column, preserveFocus: false }, {
                 enableScripts: true,
                 retainContextWhenHidden: true,
                 enableFindWidget: true,
-                localResourceRoots: [
-                    vscode.Uri.file(path.join(Config.rootPath)),
-                    vscode.Uri.file(path.join(this.extensionPath, 'build'))
-                ]
+                localResourceRoots: localResourceRoots
             });
 
             // Set the webview's initial html content
@@ -228,7 +231,7 @@ class UNotesPanel {
                 await vscode.window.showWarningMessage("Failed to load remark_settings.json file. \nNo Unotes remark formatting will be done.");
             }
         }
-        this.panel.webview.postMessage({ command: remarkSettingsCommand, settings: null });
+            this.panel.webview.postMessage({ command: remarkSettingsCommand, settings: null });
     }
 
     hotkeyExec(args) {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
                 "unotes.mediaFolder": {
                     "type": "string",
                     "default": ".media",
-                    "markdownDescription": "The folder where images are saved relative to the note"
+                    "markdownDescription": "The folder where images are saved relative to the note(e.g. `../media`). Or, an absolute path can be specified(e.g. `/media`)."
                 },
                 "unotes.newNoteTemplate": {
                     "type": "string",


### PR DESCRIPTION
Support absolute path for Media Folder.
To give VSCode permission for absolute paths, we set the localResourceRoots to that absolute folder path.
![image](https://user-images.githubusercontent.com/80378/180787610-4cad6555-3384-4c8d-9ddf-af527d619cd1.png)

**Unotes version:**
1.4.1

## Description
- Fixes #119 

## Tested
- Set "../images" to Media Folder, pasted an image from the clipboard, and the image was saved in "../images".
- Set "/images" to Media Folder, pasted an image from the clipboard, and the image was saved in "/images".

## Question
I know development is going on in the editor branch, should I rework the pull request for the editor branch?