### PR TITLE
Feature Implemented (Feature Request: Image scaling down display mode #130)

### DIFF
--- a/editor/src/TuiEditor.js
+++ b/editor/src/TuiEditor.js
@@ -26,9 +26,9 @@ import './override-katex.css'
 // root for local images
 var img_root = '';
 
-// zoom out limit percent
-var Config__img_zoom_out_limit_percent = null;
-var Temp__img_zoom_out_limit_percent = null;
+// image max width percent
+var Config__img_max_width_percent = null;
+var Temp__img_max_width_percent = null;
 
 function escapeRegExp(str) {
     return str.replace(/([.*+?^=!:${}()|[]\/\\])/g, "\\$1");
@@ -127,21 +127,21 @@ class TuiEditor extends Component {
                 image(node, context) {
                     const { origin, entering } = context;
                     const result = origin();
-                    // console.log("Config__img_zoom_out_limit_percent" + Config__img_zoom_out_limit_percent);
-                    // console.log("Temp__img_zoom_out_limit_percent" + Temp__img_zoom_out_limit_percent);
-                    let percent = Config__img_zoom_out_limit_percent;
-                    if (Temp__img_zoom_out_limit_percent) {
-                        percent = Temp__img_zoom_out_limit_percent;
+                    // console.log("Config__img_max_width_percent" + Config__img_max_width_percent);
+                    // console.log("Temp__img_max_width_percent" + Temp__img_max_width_percent);
+                    let percent = Config__img_max_width_percent;
+                    if (Temp__img_max_width_percent) {
+                        percent = Temp__img_max_width_percent;
                     }
                     switch (percent) {
                         case 10:
                         case 25:
                         case 50:
                         case 75:
-                            result.attributes.class = "zoom" + percent;
+                            result.attributes.class = "maxwidth" + percent;
                             break;
                         default:
-                            result.attributes.class = "zoom100";
+                            result.attributes.class = "maxwidth100";
                             break;
                     }
                     const httpRE = /^https?:\/\/|^data:/;
@@ -257,7 +257,7 @@ class TuiEditor extends Component {
 
     setContent(data){
         img_root = data.folderPath + '/';
-        Config__img_zoom_out_limit_percent = data.percent;
+        Config__img_max_width_percent = data.percent;
         this.state.editor.setMarkdown(data.content, false);
         this.contentSet = true;
         
@@ -283,7 +283,7 @@ class TuiEditor extends Component {
                 break;
             case 'settings':
                 this.setState({ settings: e.data.settings });
-                Config__img_zoom_out_limit_percent = e.data.settings.imageZoomOutLimitPercent;
+                Config__img_max_width_percent = e.data.settings.imageMaxWidthPercent;
                 break;
             case 'remarkSettings':
                 this.remarkSettings = e.data.settings;
@@ -296,8 +296,8 @@ class TuiEditor extends Component {
                     this.state.editor.getUI().getModeSwitch()._changeMarkdown();
                 }
                 break;
-            case 'imageZoomOut':
-                Temp__img_zoom_out_limit_percent = e.data.percent;
+            case 'imageMaxWidth':
+                Temp__img_max_width_percent = e.data.percent;
                 break;
             default:
         }

--- a/editor/src/TuiEditor.js
+++ b/editor/src/TuiEditor.js
@@ -26,6 +26,10 @@ import './override-katex.css'
 // root for local images
 var img_root = '';
 
+// zoom out limit percent
+var Config__img_zoom_out_limit_percent = null;
+var Temp__img_zoom_out_limit_percent = null;
+
 function escapeRegExp(str) {
     return str.replace(/([.*+?^=!:${}()|[]\/\\])/g, "\\$1");
 }
@@ -123,6 +127,23 @@ class TuiEditor extends Component {
                 image(node, context) {
                     const { origin, entering } = context;
                     const result = origin();
+                    // console.log("Config__img_zoom_out_limit_percent" + Config__img_zoom_out_limit_percent);
+                    // console.log("Temp__img_zoom_out_limit_percent" + Temp__img_zoom_out_limit_percent);
+                    let percent = Config__img_zoom_out_limit_percent;
+                    if (Temp__img_zoom_out_limit_percent) {
+                        percent = Temp__img_zoom_out_limit_percent;
+                    }
+                    switch (percent) {
+                        case 10:
+                        case 25:
+                        case 50:
+                        case 75:
+                            result.attributes.class = "zoom" + percent;
+                            break;
+                        default:
+                            result.attributes.class = "zoom100";
+                            break;
+                    }
                     const httpRE = /^https?:\/\/|^data:/;
                     if (httpRE.test(node.destination)){
                         return result;
@@ -236,6 +257,7 @@ class TuiEditor extends Component {
 
     setContent(data){
         img_root = data.folderPath + '/';
+        Config__img_zoom_out_limit_percent = data.percent;
         this.state.editor.setMarkdown(data.content, false);
         this.contentSet = true;
         
@@ -261,6 +283,7 @@ class TuiEditor extends Component {
                 break;
             case 'settings':
                 this.setState({ settings: e.data.settings });
+                Config__img_zoom_out_limit_percent = e.data.settings.imageZoomOutLimitPercent;
                 break;
             case 'remarkSettings':
                 this.remarkSettings = e.data.settings;
@@ -272,6 +295,9 @@ class TuiEditor extends Component {
                 } else {
                     this.state.editor.getUI().getModeSwitch()._changeMarkdown();
                 }
+                break;
+            case 'imageZoomOut':
+                Temp__img_zoom_out_limit_percent = e.data.percent;
                 break;
             default:
         }

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -26,22 +26,22 @@ code {
     min-width: 100%;
 }
 
-img.zoom10 {
+img.maxwidth10 {
   max-width: 10% !important;
 }
 
-img.zoom25 {
+img.maxwidth25 {
   max-width: 25% !important;
 }
 
-img.zoom50 {
+img.maxwidth50 {
   max-width: 50% !important;
 }
 
-img.zoom75 {
+img.maxwidth75 {
   max-width: 75% !important;
 }
 
-img.zoom100 {
+img.maxwidth100 {
   max-width: 100% !important;
 }

--- a/editor/src/index.css
+++ b/editor/src/index.css
@@ -25,3 +25,23 @@ code {
     min-height: 100vh;
     min-width: 100%;
 }
+
+img.zoom10 {
+  max-width: 10% !important;
+}
+
+img.zoom25 {
+  max-width: 25% !important;
+}
+
+img.zoom50 {
+  max-width: 50% !important;
+}
+
+img.zoom75 {
+  max-width: 75% !important;
+}
+
+img.zoom100 {
+  max-width: 100% !important;
+}

--- a/ext-src/uNotes.js
+++ b/ext-src/uNotes.js
@@ -78,6 +78,17 @@ class UNotes {
 
         context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(Config.onChange.bind(Config)));
 
+        // status Bar
+        const statusBarCommandId = 'unotes.showImageZoomPercent';
+        this.lastImageZoomPercent = Config.imageZoomOutLimitPercent;
+        this.disposables.push(
+            vscode.commands.registerCommand(statusBarCommandId, this.onShowStatusBar.bind(this))
+        );
+        this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
+        this.statusBarItem.command = statusBarCommandId;
+        context.subscriptions.push(this.statusBarItem);
+        this.onShowStatusBar();
+
         // Create view and Provider
         const uNoteProvider = new UNoteProvider(Config.rootPath);
         this.uNoteProvider = uNoteProvider;
@@ -152,6 +163,25 @@ class UNotes {
             vscode.commands.registerCommand('unotes.openWith', this.onOpenWithUnotes.bind(this))
         );
 
+        this.disposables.push(
+            vscode.commands.registerCommand('unotes.imageZoomOut_10', this.onImageZoomOut.bind(this,10))
+        );
+
+        this.disposables.push(
+            vscode.commands.registerCommand('unotes.imageZoomOut_25', this.onImageZoomOut.bind(this,25))
+        );
+
+        this.disposables.push(
+            vscode.commands.registerCommand('unotes.imageZoomOut_50', this.onImageZoomOut.bind(this,50))
+        );
+
+        this.disposables.push(
+            vscode.commands.registerCommand('unotes.imageZoomOut_75', this.onImageZoomOut.bind(this,75))
+        );
+        
+        this.disposables.push(
+            vscode.commands.registerCommand('unotes.imageZoomOut_100', this.onImageZoomOut.bind(this,100))
+        );
 
         checkWhatsNew(context);
 
@@ -413,7 +443,22 @@ class UNotes {
         }
 
     }
-    
+
+    async onImageZoomOut(percent) {
+        this.lastImageZoomPercent = percent;
+        const panel = UNotesPanel.instance();
+        if (panel) {
+            await panel.imageZoomOut(percent);
+        }
+        await this.onShowStatusBar();
+    }
+
+    async onShowStatusBar()
+    {
+        this.statusBarItem.text = `Unotes image zoom: ${this.lastImageZoomPercent}%`;
+        this.statusBarItem.show();
+    }
+
     async onRenameFolder(folder) {
         if(!folder){
             return;

--- a/ext-src/uNotes.js
+++ b/ext-src/uNotes.js
@@ -79,8 +79,8 @@ class UNotes {
         context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(Config.onChange.bind(Config)));
 
         // status Bar
-        const statusBarCommandId = 'unotes.showImageZoomPercent';
-        this.lastImageZoomPercent = Config.imageZoomOutLimitPercent;
+        const statusBarCommandId = 'unotes.showImageMaxWidthPercent';
+        this.lastImageMaxWidthPercent = Config.imageMaxWidthPercent;
         this.disposables.push(
             vscode.commands.registerCommand(statusBarCommandId, this.onShowStatusBar.bind(this))
         );
@@ -164,23 +164,23 @@ class UNotes {
         );
 
         this.disposables.push(
-            vscode.commands.registerCommand('unotes.imageZoomOut_10', this.onImageZoomOut.bind(this,10))
+            vscode.commands.registerCommand('unotes.imageMaxWidth_10', this.onImageMaxWidth.bind(this,10))
         );
 
         this.disposables.push(
-            vscode.commands.registerCommand('unotes.imageZoomOut_25', this.onImageZoomOut.bind(this,25))
+            vscode.commands.registerCommand('unotes.imageMaxWidth_25', this.onImageMaxWidth.bind(this,25))
         );
 
         this.disposables.push(
-            vscode.commands.registerCommand('unotes.imageZoomOut_50', this.onImageZoomOut.bind(this,50))
+            vscode.commands.registerCommand('unotes.imageMaxWidth_50', this.onImageMaxWidth.bind(this,50))
         );
 
         this.disposables.push(
-            vscode.commands.registerCommand('unotes.imageZoomOut_75', this.onImageZoomOut.bind(this,75))
+            vscode.commands.registerCommand('unotes.imageMaxWidth_75', this.onImageMaxWidth.bind(this,75))
         );
         
         this.disposables.push(
-            vscode.commands.registerCommand('unotes.imageZoomOut_100', this.onImageZoomOut.bind(this,100))
+            vscode.commands.registerCommand('unotes.imageMaxWidth_100', this.onImageMaxWidth.bind(this,100))
         );
 
         checkWhatsNew(context);
@@ -444,18 +444,18 @@ class UNotes {
 
     }
 
-    async onImageZoomOut(percent) {
-        this.lastImageZoomPercent = percent;
+    async onImageMaxWidth(percent) {
+        this.lastImageMaxWidthPercent = percent;
         const panel = UNotesPanel.instance();
         if (panel) {
-            await panel.imageZoomOut(percent);
+            await panel.imageMaxWidth(percent);
         }
         await this.onShowStatusBar();
     }
 
     async onShowStatusBar()
     {
-        this.statusBarItem.text = `Unotes image zoom: ${this.lastImageZoomPercent}%`;
+        this.statusBarItem.text = `Unotes image max width: ${this.lastImageMaxWidthPercent}%`;
         this.statusBarItem.show();
     }
 

--- a/ext-src/uNotesCommon.js
+++ b/ext-src/uNotesCommon.js
@@ -60,6 +60,9 @@ class UnotesConfig {
         this._onDidChange_editor_settings = new vscode.EventEmitter();
         this.onDidChange_editor_settings = this._onDidChange_editor_settings.event;
 
+        // image zoom limit
+        this.imageZoomOutLimitPercent = this.settings.editor.imageZoomOutLimitPercent;
+
         // handlebars helpers
         Handlebars.registerHelper('formatDate', function (dt, dtFormat) {
             return moment(dt).format(dtFormat);

--- a/ext-src/uNotesCommon.js
+++ b/ext-src/uNotesCommon.js
@@ -60,8 +60,8 @@ class UnotesConfig {
         this._onDidChange_editor_settings = new vscode.EventEmitter();
         this.onDidChange_editor_settings = this._onDidChange_editor_settings.event;
 
-        // image zoom limit
-        this.imageZoomOutLimitPercent = this.settings.editor.imageZoomOutLimitPercent;
+        // image max width
+        this.imageMaxWidthPercent = this.settings.editor.imageMaxWidthPercent;
 
         // handlebars helpers
         Handlebars.registerHelper('formatDate', function (dt, dtFormat) {

--- a/ext-src/uNotesPanel.js
+++ b/ext-src/uNotesPanel.js
@@ -246,6 +246,13 @@ class UNotesPanel {
         }
     }
 
+    async imageZoomOut(percent) {
+        if (this.panel.active) {
+            this.panel.webview.postMessage({ command: 'imageZoomOut', percent});
+        }
+        await this.updateContents();
+    }
+
     insertTemplate() {
         // todo
     }
@@ -279,7 +286,7 @@ class UNotesPanel {
                 const decoder = new TextDecoder();
                 const content = decoder.decode(await vscode.workspace.fs.readFile(vscode.Uri.file(this.currentPath)));
                 const folderPath = this.panel.webview.asWebviewUri(vscode.Uri.file(path.join(Config.rootPath, this.currentNote.folderPath))).path;
-                this.panel.webview.postMessage({ command: 'setContent', content, folderPath, contentPath: this.currentPath });
+                this.panel.webview.postMessage({ command: 'setContent', content, folderPath, contentPath: this.currentPath, percent: Config.imageZoomOutLimitPercent })
             }
         }
         catch (e) {

--- a/ext-src/uNotesPanel.js
+++ b/ext-src/uNotesPanel.js
@@ -246,9 +246,9 @@ class UNotesPanel {
         }
     }
 
-    async imageZoomOut(percent) {
+    async imageMaxWidth(percent) {
         if (this.panel.active) {
-            this.panel.webview.postMessage({ command: 'imageZoomOut', percent});
+            this.panel.webview.postMessage({ command: 'imageMaxWidth', percent});
         }
         await this.updateContents();
     }
@@ -286,7 +286,7 @@ class UNotesPanel {
                 const decoder = new TextDecoder();
                 const content = decoder.decode(await vscode.workspace.fs.readFile(vscode.Uri.file(this.currentPath)));
                 const folderPath = this.panel.webview.asWebviewUri(vscode.Uri.file(path.join(Config.rootPath, this.currentNote.folderPath))).path;
-                this.panel.webview.postMessage({ command: 'setContent', content, folderPath, contentPath: this.currentPath, percent: Config.imageZoomOutLimitPercent })
+                this.panel.webview.postMessage({ command: 'setContent', content, folderPath, contentPath: this.currentPath, percent: Config.imageMaxWidthPercent })
             }
         }
         catch (e) {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
                     "type": "string",
                     "default": "title_date",
                     "markdownDescription": "The template used for new notes"
+                },
+                "unotes.editor.imageZoomOutLimitPercent": {
+                    "type": "integer",
+                    "default": "100",
+                    "markdownDescription": "image zoom out limit in percent. (e.g. 10 or 25 or 50 or 75 or 100)"
                 }
             }
         },
@@ -577,6 +582,46 @@
             {
                 "command": "unotes.toggleMode",
                 "title": "Toggle Editor Mode"
+            },
+            {
+                "command": "unotes.imageZoomOut_10",
+                "title": "Image zoom out with 10%",
+                "icon": {
+                    "light": "resources/light/refresh.svg",
+                    "dark": "resources/dark/refresh.svg"
+                }
+            },
+            {
+                "command": "unotes.imageZoomOut_25",
+                "title": "Image zoom out with 25%",
+                "icon": {
+                    "light": "resources/light/refresh.svg",
+                    "dark": "resources/dark/refresh.svg"
+                }
+            },
+            {
+                "command": "unotes.imageZoomOut_50",
+                "title": "Image zoom out with 50%",
+                "icon": {
+                    "light": "resources/light/refresh.svg",
+                    "dark": "resources/dark/refresh.svg"
+                }
+            },
+            {
+                "command": "unotes.imageZoomOut_75",
+                "title": "Image zoom out with 75%",
+                "icon": {
+                    "light": "resources/light/refresh.svg",
+                    "dark": "resources/dark/refresh.svg"
+                }
+            },
+            {
+                "command": "unotes.imageZoomOut_100",
+                "title": "Image zoom out with 100%",
+                "icon": {
+                    "light": "resources/light/refresh.svg",
+                    "dark": "resources/dark/refresh.svg"
+                }
             }
         ],
         "menus": {
@@ -627,6 +672,31 @@
                     "command": "unotes.convertImages",
                     "when": "viewItem =~ /(uNoteFile)/",
                     "group": "unotesProcess@1"
+                },
+                {
+                    "command": "unotes.imageZoomOut_10",
+                    "when": "viewItem =~ /(uNoteFile)/",
+                    "group": "unotesImageZoomOut@1"
+                },
+                {
+                    "command": "unotes.imageZoomOut_25",
+                    "when": "viewItem =~ /(uNoteFile)/",
+                    "group": "unotesImageZoomOut@2"
+                },
+                {
+                    "command": "unotes.imageZoomOut_50",
+                    "when": "viewItem =~ /(uNoteFile)/",
+                    "group": "unotesImageZoomOut@3"
+                },
+                {
+                    "command": "unotes.imageZoomOut_75",
+                    "when": "viewItem =~ /(uNoteFile)/",
+                    "group": "unotesImageZoomOut@4"
+                },
+                {
+                    "command": "unotes.imageZoomOut_100",
+                    "when": "viewItem =~ /(uNoteFile)/",
+                    "group": "unotesImageZoomOut@5"
                 },
                 {
                     "command": "unotes.renameFolder",

--- a/package.json
+++ b/package.json
@@ -79,10 +79,10 @@
                     "default": "title_date",
                     "markdownDescription": "The template used for new notes"
                 },
-                "unotes.editor.imageZoomOutLimitPercent": {
+                "unotes.editor.imageMaxWidthPercent": {
                     "type": "integer",
                     "default": "100",
-                    "markdownDescription": "image zoom out limit in percent. (e.g. 10 or 25 or 50 or 75 or 100)"
+                    "markdownDescription": "image max width in percent. (e.g. 10 or 25 or 50 or 75 or 100)"
                 }
             }
         },
@@ -584,40 +584,40 @@
                 "title": "Toggle Editor Mode"
             },
             {
-                "command": "unotes.imageZoomOut_10",
-                "title": "Image zoom out with 10%",
+                "command": "unotes.imageMaxWidth_10",
+                "title": "Image max width with 10%",
                 "icon": {
                     "light": "resources/light/refresh.svg",
                     "dark": "resources/dark/refresh.svg"
                 }
             },
             {
-                "command": "unotes.imageZoomOut_25",
-                "title": "Image zoom out with 25%",
+                "command": "unotes.imageMaxWidth_25",
+                "title": "Image max width with 25%",
                 "icon": {
                     "light": "resources/light/refresh.svg",
                     "dark": "resources/dark/refresh.svg"
                 }
             },
             {
-                "command": "unotes.imageZoomOut_50",
-                "title": "Image zoom out with 50%",
+                "command": "unotes.imageMaxWidth_50",
+                "title": "Image max width with 50%",
                 "icon": {
                     "light": "resources/light/refresh.svg",
                     "dark": "resources/dark/refresh.svg"
                 }
             },
             {
-                "command": "unotes.imageZoomOut_75",
-                "title": "Image zoom out with 75%",
+                "command": "unotes.imageMaxWidth_75",
+                "title": "Image max width with 75%",
                 "icon": {
                     "light": "resources/light/refresh.svg",
                     "dark": "resources/dark/refresh.svg"
                 }
             },
             {
-                "command": "unotes.imageZoomOut_100",
-                "title": "Image zoom out with 100%",
+                "command": "unotes.imageMaxWidth_100",
+                "title": "Image max width with 100%",
                 "icon": {
                     "light": "resources/light/refresh.svg",
                     "dark": "resources/dark/refresh.svg"
@@ -674,29 +674,29 @@
                     "group": "unotesProcess@1"
                 },
                 {
-                    "command": "unotes.imageZoomOut_10",
+                    "command": "unotes.imageMaxWidth_10",
                     "when": "viewItem =~ /(uNoteFile)/",
-                    "group": "unotesImageZoomOut@1"
+                    "group": "unotesImageMaxWidth@1"
                 },
                 {
-                    "command": "unotes.imageZoomOut_25",
+                    "command": "unotes.imageMaxWidth_25",
                     "when": "viewItem =~ /(uNoteFile)/",
-                    "group": "unotesImageZoomOut@2"
+                    "group": "unotesImageMaxWidth@2"
                 },
                 {
-                    "command": "unotes.imageZoomOut_50",
+                    "command": "unotes.imageMaxWidth_50",
                     "when": "viewItem =~ /(uNoteFile)/",
-                    "group": "unotesImageZoomOut@3"
+                    "group": "unotesImageMaxWidth@3"
                 },
                 {
-                    "command": "unotes.imageZoomOut_75",
+                    "command": "unotes.imageMaxWidth_75",
                     "when": "viewItem =~ /(uNoteFile)/",
-                    "group": "unotesImageZoomOut@4"
+                    "group": "unotesImageMaxWidth@4"
                 },
                 {
-                    "command": "unotes.imageZoomOut_100",
+                    "command": "unotes.imageMaxWidth_100",
                     "when": "viewItem =~ /(uNoteFile)/",
-                    "group": "unotesImageZoomOut@5"
+                    "group": "unotesImageMaxWidth@5"
                 },
                 {
                     "command": "unotes.renameFolder",


### PR DESCRIPTION
Supported Image scaling down display mode. (Image zoom out mode)
Embedded images can be displayed smaller when you want to focus on document writing.

**Unotes version:**
1.4.2

## Description
- Fixes #130 
- Fixes #110 
- Images can now be zoomed out by a specified percentage.
- Percentages can be selected from 10% 25% 50% 75% 100%.
- Default percentages can be saved to VS Code settings.
- Percentages can be changed in the context menu.
- The current percentage is displayed in the status bar.

## Screen captures
- zoom out 100%(default)
![image](https://user-images.githubusercontent.com/80378/182072312-b4e24ba9-fe50-4eb3-86b8-9b78e8686f1c.png)

- zoom out 50%
![image](https://user-images.githubusercontent.com/80378/182072381-1d21af99-38e5-460f-8b2a-225134e84cf2.png)

- zoom out 25%
![image](https://user-images.githubusercontent.com/80378/182072497-fecfd55e-554f-4c7b-b892-9bcf3a34af76.png)

- status bar
![image](https://user-images.githubusercontent.com/80378/182073155-642e335c-1b45-4726-b4b6-d2e4d7098a84.png)

- context menu
![image](https://user-images.githubusercontent.com/80378/182073319-9f324152-eacf-48d1-8006-06464c297dec.png)
